### PR TITLE
Add install and build script for qa folder

### DIFF
--- a/qa/L0_server_example/test.sh
+++ b/qa/L0_server_example/test.sh
@@ -1,4 +1,4 @@
-# Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,6 +37,7 @@ if [ ! -z "$TEST_REPO_ARCH" ]; then
     REPO_VERSION=${REPO_VERSION}_${TEST_REPO_ARCH}
 fi
 
+bash -x ../install_test_dependencies_and_build.sh
 export CUDA_VISIBLE_DEVICES=0
 
 CLIENT_LOG=`pwd`/client.log


### PR DESCRIPTION
To simplify QA process on the CI since developer tools builds on top of the Triton container