### PR TITLE
Use the correct branch name for testing

### DIFF
--- a/qa/L0_server_example/test.sh
+++ b/qa/L0_server_example/test.sh
@@ -50,10 +50,10 @@ RET=0
 # Prepare required models for the examples
 mkdir models
 cp -r ../L0_server_unit_test/models/add_sub* ./models/.
-git clone https://github.com/triton-inference-server/server.git
+git clone --single-branch --depth=1 -b ${TRITON_SERVER_BRANCH_NAME} https://github.com/triton-inference-server/server.git
 cp -r server/docs/examples/model_repository/simple ./models/.
 # Copy over the decoupled model placed in the python_backend repository.
-git clone https://github.com/triton-inference-server/python_backend.git
+git clone --single-branch --depth=1 -b ${PYTHON_BACKEND_REPO_TAG} https://github.com/triton-inference-server/python_backend.git
 mkdir -p ./models/square_int32/1
 cp python_backend/examples/decoupled/square_model.py ./models/square_int32/1/model.py
 cp python_backend/examples/decoupled/square_config.pbtxt ./models/square_int32/config.pbtxt

--- a/qa/L0_server_unit_test/test.sh
+++ b/qa/L0_server_unit_test/test.sh
@@ -43,7 +43,7 @@ export CUDA_VISIBLE_DEVICES=0
 TEST_LOG=test.log
 
 # Copy over the decoupled model placed in the python_backend repository.
-git clone https://github.com/triton-inference-server/python_backend.git
+git clone --single-branch --depth=1 -b ${PYTHON_BACKEND_REPO_TAG} https://github.com/triton-inference-server/python_backend.git
 mkdir -p ./models/square_int32/1
 cp python_backend/examples/decoupled/square_model.py ./models/square_int32/1/model.py
 cp python_backend/examples/decoupled/square_config.pbtxt ./models/square_int32/config.pbtxt

--- a/qa/install_test_dependencies_and_build.sh
+++ b/qa/install_test_dependencies_and_build.sh
@@ -39,6 +39,7 @@ cmake --version
 
 # Install developer tools
 mkdir -p /opt/tritonserver/developer_tools/server/build && cd /opt/tritonserver/developer_tools/server/build 
-cmake -DCMAKE_INSTALL_PREFIX:PATH=/opt/tritonserver/developer_tools/server/build/install .. 
+cmake -DCMAKE_INSTALL_PREFIX:PATH=/opt/tritonserver/developer_tools/server/build/install \
+    -DTRITON_CORE_REPO_TAG=${TRITON_CORE_REPO_TAG} -DTRITON_COMMON_REPO_TAG=${TRITON_COMMON_REPO_TAG} .. 
 make install 
 cp /opt/tritonserver/developer_tools/server/build/install/lib/libtritondevelopertoolsserver.a /opt/tritonserver/lib/


### PR DESCRIPTION
Need to use the corresponding branch for testing to avoid Triton version mismatch issue if there are new changes to the API after the release branch has frozen.