### PR TITLE
Fix promise lifetime management in callback function

### DIFF
--- a/server/src/server_wrapper.cc
+++ b/server/src/server_wrapper.cc
@@ -671,7 +671,6 @@ InternalServer::InferResponseComplete(
     if (!is_decoupled) {
       infer_result->next_result_future_.reset();
       p->prev_promise_->set_value(std::move(infer_result));
-      p->prev_promise_.reset();
     } else {
       if ((flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
         // Not the last response. Need to store the promise associated with the
@@ -686,17 +685,14 @@ InternalServer::InferResponseComplete(
         // The last response.
         infer_result->next_result_future_.reset();
         p->prev_promise_->set_value(std::move(infer_result));
-        p->prev_promise_.reset();
       }
     }
   } else if (
       is_decoupled && (flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) != 0) {
     // An empty response may be the last response for decoupled models.
     p->prev_promise_->set_value(nullptr);
-    p->prev_promise_.reset();
   } else {
     p->prev_promise_->set_value(nullptr);
-    p->prev_promise_.reset();
     throw TritonException("Unexpected empty response.");
   }
 }


### PR DESCRIPTION
There is a race condition causing a `std::future_error: Broken promise` segfault when running high-concurrency async inference.

Thread 1 is waiting on the future:
```
auto fut = server->AsyncInfer(*request);
auto result = fut.get();
```

Thread 2 is in the [`InferResponseComplete`](https://github.com/triton-inference-server/developer_tools/blob/main/server/src/server_wrapper.cc#L673) callback, setting the value to the promise associated with the above future:
```
p->prev_promise_->set_value(std::move(infer_result));
p->prev_promise_.reset();   // This line gets called before the future in Thread 1 retrieves the value.
```
When the promise is reset before the result is retrieved from Thread 1, the segfault occurs.

This PR fixes this issue by removing the `p->prev_promise_.reset();` line from the callback. Since the promise is a unique_ptr, it should be deallocated when the `InferRequest` object goes out of scope. Therefore, we don't have to specifically delete it in the callback.