### PR TITLE
Fix compilation errors with clang-17

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -121,7 +121,7 @@ target_compile_options(
   triton-developer_tools-server
   PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-    -Wall -Wextra -Wno-unused-parameter -Werror>
+    -Wall -Wextra -Wno-unused-parameter -Werror -Wno-overloaded-virtual>
   $<$<CXX_COMPILER_ID:MSVC>:/Wall /D_WIN32_WINNT=0x0A00 /EHsc>
 )
 

--- a/server/include/triton/developer_tools/generic_server_wrapper.h
+++ b/server/include/triton/developer_tools/generic_server_wrapper.h
@@ -35,11 +35,11 @@
 
 namespace triton { namespace developer_tools { namespace server {
 
-class ServerOptions;
-class InferOptions;
-class RepositoryIndex;
-class NewModelRepo;
-class Tensor;
+struct ServerOptions;
+struct InferOptions;
+struct RepositoryIndex;
+struct NewModelRepo;
+struct Tensor;
 class GenericInferRequest;
 class GenericInferResult;
 using TensorAllocMap = std::unordered_map<

--- a/server/include/triton/developer_tools/server_wrapper.h
+++ b/server/include/triton/developer_tools/server_wrapper.h
@@ -381,7 +381,7 @@ std::string ModelReadyStateString(const ModelReadyState& state);
 template <
     typename Iterator, typename std::enable_if<std::is_same<
                            typename std::iterator_traits<Iterator>::value_type,
-                           std::string>::value>::type* = nullptr>
+                           std::string>::value>::type*>
 void
 InferRequest::AddInput(
     const std::string& name, const Iterator begin, const Iterator end,
@@ -410,7 +410,7 @@ InferRequest::AddInput(
 template <
     typename Iterator, typename std::enable_if<!std::is_same<
                            typename std::iterator_traits<Iterator>::value_type,
-                           std::string>::value>::type* = nullptr>
+                           std::string>::value>::type*>
 void
 InferRequest::AddInput(
     const std::string& name, const Iterator begin, const Iterator end,

--- a/server/src/server_wrapper.cc
+++ b/server/src/server_wrapper.cc
@@ -1377,8 +1377,8 @@ InternalServer::PrepareTraceManager(InferRequest& infer_request)
       trace_manager_->UpdateTraceSetting(
           infer_request.infer_options_->model_name_, new_setting);
     }
-    infer_request.trace_ = std::move(
-        trace_manager_->SampleTrace(infer_request.infer_options_->model_name_));
+    infer_request.trace_ =
+        trace_manager_->SampleTrace(infer_request.infer_options_->model_name_);
   } else if (infer_request.infer_options_->trace_) {
     LOG_MESSAGE(
         TRITONSERVER_LOG_ERROR,
@@ -1884,8 +1884,8 @@ InternalResult::FinalizeResponse(
       const void* vvalue;
       THROW_IF_TRITON_ERR(TRITONSERVER_InferenceResponseParameter(
           response, pidx, &name, &type, &vvalue));
-      params_.push_back(std::move(std::unique_ptr<ResponseParameters>(
-          new ResponseParameters(name, type, vvalue))));
+      params_.push_back(std::unique_ptr<ResponseParameters>(
+          new ResponseParameters(name, type, vvalue)));
     }
 
     uint32_t output_count;
@@ -2077,8 +2077,9 @@ InferResult::DebugString()
           response_json, triton::common::TritonJson::ValueType::OBJECT);
       THROW_IF_TRITON_ERR(
           output_json.AddStringRef("name", infer_output.first.c_str()));
-      const char* datatype_str = DataTypeString(output->data_type_).c_str();
-      THROW_IF_TRITON_ERR(output_json.AddStringRef("datatype", datatype_str));
+      std::string datatype_str = DataTypeString(output->data_type_);
+      THROW_IF_TRITON_ERR(
+          output_json.AddStringRef("datatype", datatype_str.c_str()));
       triton::common::TritonJson::Value shape_json(
           response_json, triton::common::TritonJson::ValueType::ARRAY);
       for (size_t j = 0; j < output->shape_.size(); j++) {


### PR DESCRIPTION
When building with clang-17 there are a number of warnings/errors that crop up. This PR silences them.
